### PR TITLE
[UPDATE] The `device.abis` is now list of strings.

### DIFF
--- a/lib/src/main/kotlin/dev/hossain/android/catalogparser/Config.kt
+++ b/lib/src/main/kotlin/dev/hossain/android/catalogparser/Config.kt
@@ -1,5 +1,9 @@
 package dev.hossain.android.catalogparser
 
+/**
+ * Contains CSV header names found in Google Play Device Catalog
+ * See https://play.google.com/console/about/devicecatalog/ to get latest version.
+ */
 object Config {
     const val CSV_MULTI_VALUE_SEPARATOR = ";"
 

--- a/lib/src/main/kotlin/dev/hossain/android/catalogparser/Parser.kt
+++ b/lib/src/main/kotlin/dev/hossain/android/catalogparser/Parser.kt
@@ -16,6 +16,11 @@ import dev.hossain.android.catalogparser.Config.CSV_KEY_SOC
 import dev.hossain.android.catalogparser.Config.CSV_MULTI_VALUE_SEPARATOR
 import dev.hossain.android.catalogparser.models.AndroidDevice
 
+/**
+ * CSV parser for Google Play Device Catalog found in Google Play Console
+ * See https://play.google.com/console/about/devicecatalog/ to get latest version.
+ * @see Config
+ */
 class Parser {
 
     private val csvReader: CsvReader = csvReader()
@@ -64,7 +69,7 @@ class Parser {
                 processorName = processorName,
                 screenSizes = screenSizes.split(CSV_MULTI_VALUE_SEPARATOR),
                 screenDensities = screenDensities.split(CSV_MULTI_VALUE_SEPARATOR).map { it.toInt() },
-                abis = abis,
+                abis = abis.split(CSV_MULTI_VALUE_SEPARATOR),
                 sdkVersions = sdkVersions.split(CSV_MULTI_VALUE_SEPARATOR).map { it.toInt() },
                 openGlEsVersions = openGlEsVersions.split(CSV_MULTI_VALUE_SEPARATOR)
             )

--- a/lib/src/main/kotlin/dev/hossain/android/catalogparser/models/AndroidDevice.kt
+++ b/lib/src/main/kotlin/dev/hossain/android/catalogparser/models/AndroidDevice.kt
@@ -1,18 +1,67 @@
 package dev.hossain.android.catalogparser.models
 
 /**
- * Model class for
+ * Model class for Android Device with device attributes found in the official Device Catalog.
+ * See https://play.google.com/console/about/devicecatalog/ to get latest version.
  */
 class AndroidDevice(
+    /**
+     * Device manufacturer name.
+     * Examples: Acer, LG, Samsung
+     */
     val manufacturer: String,
+
+    /**
+     * Device model name (usually public facing)
+     * Examples: Iconia One 7, S13, ZenFone 4 (ZE554KL)
+     */
     val modelName: String,
+
+    /**
+     * Device model code internally used by manufacturer
+     * Examples: ASUS_Z01KD_3, K00X_1, BLU_NEO_X_LTE
+     */
     val modelCode: String,
+
+    /**
+     * Device RAM
+     * Examples: 934MB, 459MB, 1942MB, 3770MB
+     */
     val ram: String,
+
+    /**
+     * Device form factor.
+     * Examples: Phone, TV, Tablet
+     */
     val formFactor: String,
+
+    /**
+     * Examples: Mediatek MT6572A, Qualcomm MSM8909, Rockchip RK3326, Spreadtrum SC9832A
+     */
     val processorName: String,
+
+    /**
+     * Examples: 1024x600, 1366x768, 480x854, 800x1280
+     */
     val screenSizes: List<String>,
+
+    /**
+     * Examples: 160, 213, 240, 300, 320
+     */
     val screenDensities: List<Int>,
-    val abis: String,
+
+    /**
+     * Examples: arm64-v8a, armeabi, armeabi-v7a
+     */
+    val abis: List<String>,
+
+    /**
+     * Examples: 23, 24, 27
+     */
     val sdkVersions: List<Int>,
+
+    /**
+     * Examples: 2.0, 3.0, 3.1, 3.2
+     */
     val openGlEsVersions: List<String>
 )

--- a/lib/src/test/kotlin/dev/hossain/android/catalogparser/ParserTest.kt
+++ b/lib/src/test/kotlin/dev/hossain/android/catalogparser/ParserTest.kt
@@ -2,9 +2,6 @@ package dev.hossain.android.catalogparser
 
 import com.google.gson.Gson
 import dev.hossain.android.catalogparser.models.AndroidDevice
-import java.io.File
-import java.nio.file.Path
-import java.nio.file.Paths
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -67,7 +64,7 @@ class ParserTest {
         assertEquals("Qualcomm SDM855", device.processorName)
         assertEquals(listOf("1440x3040"), device.screenSizes)
         assertEquals(listOf(560), device.screenDensities)
-        assertEquals("arm64-v8a;armeabi;armeabi-v7a", device.abis)
+        assertEquals(listOf("arm64-v8a", "armeabi", "armeabi-v7a"), device.abis)
         assertEquals(listOf(29, 30), device.sdkVersions)
         assertEquals(listOf("3.2"), device.openGlEsVersions)
     }


### PR DESCRIPTION
Updated tests and documentation.