### PR TITLE
Fix code block rendering in details sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Discard reasons:
   Unknown form factor: Desktop: 18
   Missing required field: RAM (TotalMem): 13
 ```
+
 </details>
 
 #### Advanced Configuration


### PR DESCRIPTION
Add missing blank line before </details> closing tag to ensure proper Markdown rendering inside HTML details elements.